### PR TITLE
Simple fix for mpt-sln when user passes a sln file to --sln-file=

### DIFF
--- a/mpt-sln/Program.cs
+++ b/mpt-sln/Program.cs
@@ -25,7 +25,7 @@ namespace mptsln
 				{ "references", b => references = b },
 			};
 			p.Parse(args);
-			if (String.IsNullOrWhiteSpace (sln_file) == false)
+			if (String.IsNullOrWhiteSpace (sln_file) == true)
 			{
 				Console.WriteLine("--sln-file=some.sln is not given");
 				return (int)ExitCode.NoSolutionFileSpecified;


### PR DESCRIPTION
mpt-sln complains with "--sln-file=some.sln is not given" when user does provide the sln file because inverted conditional.  This commit fixes that.